### PR TITLE
Enhances method for retrieving task statuses in the `CambAI` class

### DIFF
--- a/cambai/__init__.py
+++ b/cambai/__init__.py
@@ -272,7 +272,11 @@ class CambAI:
         return response.json()
 
 
-    def get_dubbing_task_status(self, task_id: str) -> TaskStatus:
+    def get_task_status(
+        self,
+        task: Literal["tts", "dubbing", "transcription"],
+        task_id: str
+        ) -> TaskStatus:
         """
         Retrieves the status of a specific dubbing task.
 
@@ -289,8 +293,14 @@ class CambAI:
             HTTPError: If the GET request to the API endpoint fails.
         """
 
+        if task == "dubbing":
+            url: str = self.create_api_endpoint(f"end_to_end_dubbing/{task_id}")
+        if task == "tts":
+            url: str = self.create_api_endpoint(f"tts/{task_id}")
+        if task == "transcription":
+            url: str = self.create_api_endpoint(f"create_transcription/{task_id}")
+
         # Construct the API endpoint URL for retrieving the status of a specific dubbing task
-        url: str = self.create_api_endpoint(f"end_to_end_dubbing/{task_id}")
 
         # Send a GET request to the API endpoint
         response = self.session.get(url)
@@ -379,7 +389,7 @@ class CambAI:
         # Enter a loop to periodically check the status of the dubbing task
         while True:
             # Get the current status of the dubbing task
-            task = self.get_dubbing_task_status(task_id)
+            task = self.get_task_status("dubbing", task_id)
 
             # If debug is True, print the task status and run ID
             if debug:
@@ -402,7 +412,7 @@ class CambAI:
                 sleep(1)
 
         # Get the final status of the dubbing task
-        task = self.get_dubbing_task_status(task_id)
+        task = self.get_task_status("dubbing", task_id)
 
         # If the run ID is None, raise an APIError
         if task["run_id"] is None:
@@ -481,17 +491,7 @@ class CambAI:
             TaskStatus: The status of the TTS task.
         """
 
-        # Create the API endpoint URL using the provided task ID
-        url: str = self.create_api_endpoint(f"tts/{task_id}")
-
-        # Send the GET request to the API
-        response = self.session.get(url)
-
-        # Raise an exception if the request was unsuccessful
-        response.raise_for_status()
-
-        # Return the JSON response from the API, which includes the task status
-        return response.json()
+        return self.get_task_status("tts", task_id)
 
 
     def get_tts_result(self, run_id: int, output_directory: Optional[str]) -> None:

--- a/cambai/__init__.py
+++ b/cambai/__init__.py
@@ -278,34 +278,36 @@ class CambAI:
         task_id: str
         ) -> TaskStatus:
         """
-        Retrieves the status of a specific dubbing task.
+        Retrieves the status of a specific task.
 
-        This method sends a GET request to the "end_to_end_dubbing/{task_id}" endpoint of the Camb
-        AI API. The task_id is used to identify the specific dubbing task.
+        This method sends a GET request to the appropriate endpoint of the Camb
+        AI API based on the task type. The task_id is used to identify the specific task.
 
         Args:
-            task_id (str): The ID of the dubbing task.
+            - task (str): The type of the task. Must be one of 'dubbing', 'tts', or 'transcription'.
+            - task_id (str): The ID of the task.
 
         Returns:
-            DubbingTaskStatus: The status of the dubbing task as a dictionary.
+            - TaskStatus: The status of the task as a dictionary.
 
         Raises:
-            HTTPError: If the GET request to the API endpoint fails.
+            - ValueError: If the task type is not valid.
+            - HTTPError: If the GET request to the API endpoint fails.
         """
 
-        # If 'task' is not one of the valid task types, raise a ValueError
-        if task not in ["tts", "dubbing", "transcription"]:
-            raise ValueError("Invalid task type. Must be one of 'dubbing', 'tts',"
-                             "or 'transcription'")
+        # Initialize 'url' with an empty string
+        url: str = ""
 
-        url: str = "" # Default value for 'url'
-
+        # Determine the appropriate API endpoint based on the task type
         if task == "dubbing":
             url: str = self.create_api_endpoint(f"end_to_end_dubbing/{task_id}")
-        if task == "tts":
+        elif task == "tts":
             url: str = self.create_api_endpoint(f"tts/{task_id}")
-        if task == "transcription":
+        elif task == "transcription":
             url: str = self.create_api_endpoint(f"create_transcription/{task_id}")
+        else:
+            raise ValueError("Invalid task type. Must be one of 'dubbing', 'tts',"
+                             "or 'transcription'")
 
         # Send a GET request to the API endpoint
         response = self.session.get(url)

--- a/cambai/__init__.py
+++ b/cambai/__init__.py
@@ -611,8 +611,8 @@ class CambAI:
                           desc=f"Waiting {polling_interval} seconds before checking status again"):
                 sleep(1)
 
-        # Get the status of the dubbing task
-        task = self.get_dubbing_task_status(task_id)
+        # Get the status of the TTS task
+        task = self.get_task_status(task="tts", task_id=task_id)
 
         # Raise an error if the run ID is None
         if task["run_id"] is None:

--- a/cambai/__init__.py
+++ b/cambai/__init__.py
@@ -293,14 +293,19 @@ class CambAI:
             HTTPError: If the GET request to the API endpoint fails.
         """
 
+        # If 'task' is not one of the valid task types, raise a ValueError
+        if task not in ["tts", "dubbing", "transcription"]:
+            raise ValueError("Invalid task type. Must be one of 'dubbing', 'tts',"
+                             "or 'transcription'")
+
+        url: str = "" # Default value for 'url'
+
         if task == "dubbing":
             url: str = self.create_api_endpoint(f"end_to_end_dubbing/{task_id}")
         if task == "tts":
             url: str = self.create_api_endpoint(f"tts/{task_id}")
         if task == "transcription":
             url: str = self.create_api_endpoint(f"create_transcription/{task_id}")
-
-        # Construct the API endpoint URL for retrieving the status of a specific dubbing task
 
         # Send a GET request to the API endpoint
         response = self.session.get(url)


### PR DESCRIPTION
Refactors and enhances the method for retrieving task statuses in the CambAI class. The changes consolidate the methods for getting the status of various tasks (dubbing, TTS, transcription) into a single method, `get_task_status`, which improves code maintainability and readability.

- Replaced `get_dubbing_task_status` and `get_tts_task_status` with a single `get_task_status` method.
- The `get_task_status` method now handles three types of tasks: `dubbing`, `tts`, and `transcription`.
- Added a check to raise a ValueError if an invalid task type is provided.
- Improved error messages for better debugging.